### PR TITLE
Support for dataType ajax parameter

### DIFF
--- a/jquery.videosub.js
+++ b/jquery.videosub.js
@@ -82,6 +82,7 @@
           return $.ajax({
             method: 'get',
             url: src,
+            dataType: o.dataType,
             success: el.update
           });
         }
@@ -107,6 +108,7 @@
   $.fn.videoSub.defaults = {
     containerClass: 'videosub-container',
     barClass: 'videosub-bar',
-    useBarDefaultStyle: true
+    useBarDefaultStyle: true,
+    dataType: 'text'
   };
 })(jQuery);


### PR DESCRIPTION
Because I have a project where the subtitles are on a remote location but only could be fetched with jsonp type jquery ajax, so I added the parameter.
